### PR TITLE
Fix issue when pressing any 2 operators consecutively after inputting first operand

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function appendDecimal() {
 function operation(op) {
     const display = document.getElementById("calcarea");
     const inputValue = parseFloat(display.textContent);
-    
+
     if (firstOperand === null) {
         firstOperand = inputValue;
     } else if (operator) {
@@ -50,7 +50,7 @@ function operation(op) {
 }
 
 function calculate(silent = false) {
-    if (operator === null || firstOperand === null) {
+    if (operator === null || firstOperand === null || waitingForSecondOperand) {
         return parseFloat(document.getElementById("calcarea").textContent);
     }
     


### PR DESCRIPTION
### Bugfix: Incorrect Calculation When Switching Operators
#### Description
After entering an operand and an operator, if the user presses another operator without entering a second operand, the code incorrectly calculates the result of first operand applied to itself using the initially entered operator.
---


#### Steps to Reproduce
- Enter any number (e.g., ```5```).
- Click on any operator (e.g., ```*```).
- Click again on any operator.
- The calculator displays the product of first entered multiplied by itself (e.g., ```5 * 5 = 25```).